### PR TITLE
Flush output stream (output was being truncated at 96 kb)

### DIFF
--- a/RptToXml/RptDefinitionWriter.cs
+++ b/RptToXml/RptDefinitionWriter.cs
@@ -74,6 +74,7 @@ namespace RptToXml
 			writer.WriteStartDocument();
 			ProcessReport(Report, writer);
 			writer.WriteEndDocument();
+			writer.Flush();
 		}
 
 		private void ProcessReport(ReportDocument report, XmlWriter writer)


### PR DESCRIPTION
Bug fix affecting any report with output larger than 96 kb. My gut feel is that it should be pushed upstream to the VB.NET sources as well.
