### PR TITLE
Enable prior GetTables for subreports.

### DIFF
--- a/RptToXml/RptDefinitionWriter.cs
+++ b/RptToXml/RptDefinitionWriter.cs
@@ -182,8 +182,10 @@ namespace RptToXml
 			WriteAndTraceStartElement(writer, "Database");
 
 			GetTableLinks(report, writer);
-			//GetTables(report, writer);
-			GetReportClientTables(this.ReportClientDocument, writer);
+            if (report.IsSubreport)
+                GetTables(report, writer);
+            else
+                GetReportClientTables(this.ReportClientDocument, writer);
 
 			writer.WriteEndElement();
 


### PR DESCRIPTION
I noticed that the ReportClientDocument model is not available for subreports.

Might need to devise an alternative method to process subreports.  Maybe export subreport to temp file and parse the temp file.
