### PR TITLE
Fix for Crystal Reports maximum processing jobs limit.

### DIFF
--- a/RptToXml/RptDefinitionWriter.cs
+++ b/RptToXml/RptDefinitionWriter.cs
@@ -286,6 +286,7 @@ namespace RptToXml
 			writer.WriteAttributeString("Name", fd.Name);
 			writer.WriteAttributeString("ShortName", fd.ShortName);
 			writer.WriteAttributeString("Type", fd.Type.ToString());
+            writer.WriteAttributeString("UseCount", fd.UseCount.ToString());
 			
 			writer.WriteEndElement();
 		}


### PR DESCRIPTION
Error Thrown:
{"The maximum report processing jobs limit configured by your system administrator has been reached."}

Reference:
http://devlibrary.businessobjects.com/businessobjectsxir2/en/en/CrystalReports_dotNET_SDK/crsdk_net_doc/doc/crsdk_net_doc/html/crconsdkfundamentalsscalabilityclosemethod.htm

BTW, thanks for this awesome RptToXml project.
