### PR TITLE
catch an exception  …

### DIFF
--- a/RptToXml/RptDefinitionWriter.cs
+++ b/RptToXml/RptDefinitionWriter.cs
@@ -32,10 +32,19 @@ namespace RptToXml
 		{
 			_createdReport = true;
 			_report = new ReportDocument();
-			_report.Load(filename, OpenReportMethod.OpenReportByTempCopy);
-			_rcd = _report.ReportClientDocument;
+			try
+			{
+				_report.Load(filename, OpenReportMethod.OpenReportByTempCopy);
+				_oleCompoundFile = new CompoundFile(filename);
+			}
+			catch (System.IO.IOException ex)
+			{
+				Trace.WriteLine(ex.Message);
+				Dispose(true);
+				Environment.Exit(5);
+			}
 
-			_oleCompoundFile = new CompoundFile(filename);
+			_rcd = _report.ReportClientDocument;
 
 			Trace.WriteLine("Loaded report");
 		}


### PR DESCRIPTION
handle the exception from the two load methods if the rpt file is not accessible due to being open in CR Designer for instance.

Should _oleCompoundFile be added to Dispose()?