### PR TITLE
default path on wildcard, pictureobject graphiclocation

### DIFF
--- a/RptToXml/ConditionFormulas.cs
+++ b/RptToXml/ConditionFormulas.cs
@@ -138,6 +138,15 @@ namespace RptToXml
 					writer.WriteAttributeString(GetShortEnumName(formulaType), cf.Text);
 			}
 
+            if (ro is CRReportDefModel.PictureObject)
+            {
+                var ro_p = (CRReportDefModel.PictureObject)ro;
+                var cf = ro_p.GraphicLocationFormula;
+
+                if (!String.IsNullOrEmpty(cf.Text))
+                    writer.WriteAttributeString("GraphicLocation", cf.Text);
+            }
+
 			writer.WriteEndElement();
 		}
 

--- a/RptToXml/Program.cs
+++ b/RptToXml/Program.cs
@@ -38,11 +38,12 @@ namespace RptToXml
 			else
 			{
 				var directory = Path.GetDirectoryName(rptPathArg);
-				if (!String.IsNullOrEmpty(directory))
-				{
-					var matchingFiles = Directory.GetFiles(directory, searchPattern: Path.GetFileName(rptPathArg));
-					rptPaths.AddRange(matchingFiles.Where(ReportFilenameValid));
-				}
+                if (String.IsNullOrEmpty(directory))
+                {
+                    directory = ".";
+                }
+                var matchingFiles = Directory.GetFiles(directory, searchPattern: Path.GetFileName(rptPathArg));
+                rptPaths.AddRange(matchingFiles.Where(ReportFilenameValid));
 			}
 
 			if (rptPaths.Count == 0)


### PR DESCRIPTION
- When running with a wilcard without a path (e.g. *.rpt), set the path to "." (current folder).
- Added a property for the file path formula on Picture Objects.
