### PR TITLE
Parallelize file processing

### DIFF
--- a/RptToXml/Program.cs
+++ b/RptToXml/Program.cs
@@ -60,25 +60,28 @@ namespace RptToXml
 
 			foreach (string rptPath in rptPaths)
 			{
-				try
-				{
-					Trace.WriteLine("Dumping " + rptPath);
+				string xmlPath = args.Length > 1 + ignoreErrFlag ?
+					args[1] : Path.ChangeExtension(rptPath, "xml");
+				DumpFile(rptPath, xmlPath, ignoreErrFlag == 1);
+			}
+		}
+		static void DumpFile(string rptPath, string xmlPath, bool ignoreErr)
+		{
+			try
+			{
+				Trace.WriteLine("Dumping " + rptPath);
 
-					using (var writer = new RptDefinitionWriter(rptPath))
-					{
-						string xmlPath = args.Length > 1 + ignoreErrFlag ?
-							args[1] : Path.ChangeExtension(rptPath, "xml");
-						writer.WriteToXml(xmlPath);
-					}
-
-				}
-				catch (Exception ex)
+				using (var writer = new RptDefinitionWriter(rptPath))
 				{
-					if (ignoreErrFlag == 1)
-						Trace.WriteLine(ex.Message);
-					else
-						throw ex;
+					writer.WriteToXml(xmlPath);
 				}
+			}
+			catch (Exception ex)
+			{
+				if (ignoreErr)
+					Trace.WriteLine(ex.Message);
+				else
+					throw ex;
 			}
 		}
 		static void recursiveFileList(List<string> list, string directory)

--- a/RptToXml/Program.cs
+++ b/RptToXml/Program.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 
 namespace RptToXml
 {
@@ -58,12 +59,12 @@ namespace RptToXml
 				rptPaths.Add(rptPathArg);
 			}
 
-			foreach (string rptPath in rptPaths)
+			Parallel.ForEach(rptPaths, rptPath =>
 			{
 				string xmlPath = args.Length > 1 + ignoreErrFlag ?
 					args[1] : Path.ChangeExtension(rptPath, "xml");
 				DumpFile(rptPath, xmlPath, ignoreErrFlag == 1);
-			}
+			});
 		}
 		static void DumpFile(string rptPath, string xmlPath, bool ignoreErr)
 		{


### PR DESCRIPTION
When dumping multiple files (in my case ~300), processing them one at a time can take a long time.
This change replaces the `foreach` with a [`Parallel.ForEach`](https://learn.microsoft.com/en-us/dotnet/api/system.threading.tasks.parallel.foreach?view=netframework-4.0#system-threading-tasks-parallel-foreach-1(system-collections-generic-ienumerable((-0))-system-action((-0)))), which allows .NET to dynamically parallelize iterations, processing multiple files simultaneously.